### PR TITLE
set curl as required binary

### DIFF
--- a/ex.sh
+++ b/ex.sh
@@ -499,6 +499,7 @@ sudo ./ex.sh install${normal}"
         fi
     fi
     #
+    check_command curl "required to download the xray installation script"
     if bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install
     then
         echo -e "${green}xray installed${normal}"


### PR DESCRIPTION
test steps
```
# mv /usr/bin/curl /usr/bin/curl.back
# curl
-bash: curl: command not found
```
before the change
```
# cd easy-xray/
# ./ex.sh install
./ex.sh: line 502: curl: command not found
xray installed
customgeo.dat copied to /usr/local/share/xray/
cp: cannot stat './cert.pem': No such file or directory
cp: cannot stat './cert.key': No such file or directory
Generate configs? (Y/n)
```
after the change
```
# vim ./ex.sh
# ./ex.sh install
curl not found; required to download the xray installation script
# 
# mv /usr/bin/curl.back /usr/bin/curl
# ./ex.sh install
curl found
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 31107  100 31107    0     0   125k      0 --:--:-- --:--:-- --:--:--  125k
info: Installing Xray v1.8.24 for x86_64
info: unzip is installed.
Downloading Xray archive: https://github.com/XTLS/Xray-core/releases/download/v1.8.24/Xray-linux-64.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 13.6M  100 13.6M    0     0  20.9M      0 --:--:-- --:--:-- --:--:-- 20.9M
ok.
Downloading verification file for Xray archive: https://github.com/XTLS/Xray-core/releases/download/v1.8.24/Xray-linux-64.zip.dgst
ok.
...
```
