### PR TITLE
Modify default behaviour of "./ex.sh link" command

### DIFF
--- a/ex.sh
+++ b/ex.sh
@@ -916,8 +916,9 @@ Here is a list of all the commands available:
                       but don't delete the user configs
     ${bold}resume ${underl}usernames${normal}  add users from suspended configs to the server config
     ${bold}push${normal}            copy config to xray's dir and restart xray
-    ${bold}link ${underl}config${normal}     convert user config to a link acceptable by
-                    client applications such as Hiddify or V2ray
+    ${bold}link ${underl}[config]${normal}     convert user config to a link acceptable by
+                    client applications such as Hiddify or V2ray;
+                    if config is omitted, generate conf/client_links.txt
     ${bold}stats${normal}           print some traffic statistics and write to stats.log
     ${bold}stats reset${normal}     print statistics then set them to zero
     ${bold}import ${underl}from${normal} ${underl}to${normal}  import users from one directory that contains

--- a/ex.sh
+++ b/ex.sh
@@ -708,8 +708,23 @@ then
     conf_file=$2
     if [ -v $conf_file ]
     then
-        echo -e "${red}no config is given${normal}"
-        exit 1
+        if ! ls -U conf/config_client_*.json 1> /dev/null 2>&1; then
+            echo -e "${red}no config is given, and there are no any client configs${normal}"
+            exit 1
+        fi
+        echo -e "${yellow}no config is given, a list of client-link pairs is
+written to \033[33;3mconf/client_links.txt${yellow} from the following files:${normal}"
+        file="conf/client_links.txt"
+        : > $file
+        for conf_file in conf/config_client_*.json; do
+            echo -e "\033[33;3m  - ${conf_file}${normal}"
+            basename=$(basename $conf_file .json)
+            client=${basename#config_client_}
+            link=$(generate_link $conf_file)
+            echo -e "${client}\n$link\n" >> $file
+        done
+        sed -i '$d' $file
+        exit 0
     fi
     if [ ! -f $conf_file ]
     then


### PR DESCRIPTION
From the last commit's message:
```
modify default behaviour of "./ex.sh link" command

When executed without a "conf_file" argument, generate the client-link
pair from each config file and write it to "conf/client_links.txt".
```